### PR TITLE
Add Docker compose to run full stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# My Newro Factory Monorepo
+
+This repository combines three projects that make up the Newro Factory application:
+
+- **`db-newro-factory`** – MySQL database with initial data and scripts.
+- **`newro-factory`** – Spring based backend application.
+- **`mnf-front`** – Angular 20 frontend.
+
+A top level `docker-compose.yml` file allows you to run all parts together with a single command.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Quick Start
+
+Build and start the database, backend and frontend containers:
+
+```bash
+docker compose up --build
+```
+
+The services will be available at:
+
+- Backend: [http://localhost:8080/qlf](http://localhost:8080/qlf)
+- Frontend: [http://localhost:4200](http://localhost:4200)
+- MySQL: `localhost:33006` (username `adminnewro`, password `Qwerty1234`)
+
+To stop the stack:
+
+```bash
+docker compose down
+```
+
+Each sub‑project still contains its own README with additional details.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3.8"
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: mysql-newro
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: Qwerty1234
+      MYSQL_DATABASE: newro-factory-db
+      MYSQL_USER: adminnewro
+      MYSQL_PASSWORD: Qwerty1234
+    ports:
+      - "33006:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+      - ./db-newro-factory/sql:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "adminnewro", "-pQwerty1234"]
+      timeout: 20s
+      retries: 10
+      interval: 10s
+      start_period: 40s
+
+  backend:
+    build:
+      context: ./newro-factory
+    container_name: newro-factory-webapp
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./newro-factory/persistence/logs:/usr/local/tomcat/logs
+
+  frontend:
+    build:
+      context: ./mnf-front
+    container_name: mnf-front
+    depends_on:
+      - backend
+    ports:
+      - "4200:80"
+
+volumes:
+  db-data:
+

--- a/newro-factory/Dockerfile
+++ b/newro-factory/Dockerfile
@@ -16,6 +16,12 @@ RUN mvn -B dependency:go-offline
 # Copier le reste des sources
 COPY . .
 
+# Provide default configuration using the example files
+RUN cp persistence/src/main/resources/database_exemple.properties \
+        persistence/src/main/resources/database.properties && \
+    cp service/src/main/resources/security_exemple.properties \
+        service/src/main/resources/security.properties
+
 # Compiler le module webapp et ses dépendances
 RUN mvn -pl webapp -am clean package -DskipTests
 

--- a/newro-factory/README.md
+++ b/newro-factory/README.md
@@ -20,7 +20,7 @@ To build and start the application:
 This will:
 1. Build the Docker image using the Dockerfile
 2. Start the container with the correct port mapping
-3. Make the application available at http://localhost:8081/qlf
+3. Make the application available at http://localhost:8080/qlf
 
 ### Stopping the Application
 
@@ -57,5 +57,4 @@ To build the project without Docker:
 ```bash
 mvn clean package
 ```
-
 The WAR file will be generated at `webapp/target/qlf.war`.

--- a/newro-factory/run.sh
+++ b/newro-factory/run.sh
@@ -10,8 +10,7 @@ echo "Building and starting the application..."
 docker compose up --build -d
 
 echo "Application is starting..."
-echo "It will be available at http://localhost:8081/qlf"
+echo "It will be available at http://localhost:8080/qlf"
 echo "Use the following command to view logs:"
 echo "  docker-compose logs -f"
-echo "To stop the application, run:"
-echo "  docker-compose down"
+echo "To stop the application, run:"echo "  docker-compose down"

--- a/newro-factory/stop.sh
+++ b/newro-factory/stop.sh
@@ -2,5 +2,4 @@
 
 echo "=== Stopping Newro Factory Application ==="
 docker-compose down
-
 echo "Application stopped successfully."


### PR DESCRIPTION
## Summary
- provide repository-level README with quick start instructions
- add root `docker-compose.yml` to run database, backend and frontend together
- update backend Dockerfile to copy example properties for default config
- adjust scripts and docs to use port 8080
- ensure run/stop scripts end with newline

## Testing
- `npm test --silent --prefix mnf-front` *(fails: ng not found)*
- `mvn -q -f newro-factory/pom.xml test` *(fails: mvn not found)*


------
https://chatgpt.com/codex/tasks/task_e_686da0c530c48324924305003f48571c